### PR TITLE
fix schedule link for post-workshop page

### DIFF
--- a/_includes/custom-schedule.html
+++ b/_includes/custom-schedule.html
@@ -99,7 +99,7 @@
       </tr>
       <tr>               <!-- row 6   -->
         <td>End</td>
-        <td><a href="{{ site.url }}{{ site.baseurl }}/07-post-workshop/index.html" target="_blank">Post-workshop help & survey</a></td>
+        <td><a href="{{ site.url }}{{ site.baseurl }}/08-post-workshop/index.html" target="_blank">Post-workshop help & survey</a></td>
       </tr>
     </table>
   </div>


### PR DESCRIPTION
post-workshop page link was broken on the home page schedule. This fixes it.