### PR TITLE
trying to generalize and adapt specific Carpentries CoCc references since i don't think they'll want to review our incidents. This may be a bit too much?

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -5,8 +5,73 @@ title: "Contributor Code of Conduct"
 As contributors and maintainers of this project,
 we pledge to follow the [Carpentry Code of Conduct][coc].
 
-Instances of abusive, harassing, or otherwise unacceptable behavior
-may be reported by following our [reporting guidelines][coc-reporting].
+It is encouraged to read and understand the expectations 
+laid out by this Code of Conduct. Some selected excerpts 
+are re-stated here:
 
-[coc]: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html
-[coc-reporting]: https://docs.carpentries.org/topic_folders/policies/incident-reporting.html
+**Expected behaviour**
+
+Everyone who participates in this workshop is required to 
+conform to this Code of Conduct. It applies to all spaces 
+used in the administration of this material including, but 
+not limited to, virtual or in-person workshops, email lists, 
+and online forums such as GitHub, Slack and Twitter. Workshop 
+hosts are expected to assist with the enforcement of the Code 
+of Conduct. By participating, participants indicate their 
+acceptance of the procedures by which The Carpentries resolves 
+any Code of Conduct incidents, which may include storage and 
+processing of their personal information.
+
+All participants in our events and communications are expected to 
+show respect and courtesy to others. All interactions should be 
+professional regardless of platform: either online or in-person. 
+In order to foster a positive and professional learning environment 
+we encourage the following kinds of behaviours:
+
+* Use welcoming and inclusive language
+
+* Be respectful of different viewpoints and experiences
+
+* Gracefully accept constructive criticism
+
+* Focus on what is best for the community
+
+* Show courtesy and respect towards other community members
+
+**Unacceptable behaviour**
+
+Examples of unacceptable behaviour by participants at any Carpentries event/platform include:
+
+* written or verbal comments which have the effect of excluding people on the basis of membership of any specific group
+
+* causing someone to fear for their safety, such as through stalking, following, or intimidation
+
+* violent threats or language directed against another person
+
+* the display of sexual or violent images
+
+* unwelcome sexual attention
+
+* nonconsensual or unwelcome physical contact
+
+* sustained disruption of talks, events or communications
+
+* insults or put downs
+
+* sexist, racist, homophobic, transphobic, ableist, or exclusionary jokes
+
+* excessive swearing
+
+* incitement to violence, suicide, or self-harm
+
+* continuing to initiate interaction (including photography or recording) with someone after being asked to stop
+
+* publication of private communication without consent
+
+**Consequences of Unacceptable behaviour**
+
+Instances of abusive, harassing, or otherwise unacceptable behavior
+may be reported to any of the workshop convenors, who will assess the
+incident and may determine whether to initiate a review of the
+incident with a committee of workshop convenors in a manner similar to 
+official Carpentries incident response workflows.


### PR DESCRIPTION
Pulled some of the content out of the document we reference and generalized it to remove the Carpentries-officialness from it a bit. This would commit us to reviewing and working through any CoC breaches as if we were a CoC committe of the Carpentries, which is a lot, but is what we would owe our learners if we were notified of any breach of CoC.
