### PR TITLE
Included additional timeslot in schedule

### DIFF
--- a/_includes/custom-schedule.html
+++ b/_includes/custom-schedule.html
@@ -42,6 +42,10 @@
           </em>
         </td>
       </tr>
+      <tr>
+        <td>16:30</td>      <!-- time   -->
+        <td>Return to Main Room</td>    <!-- content -->
+      </tr>
       <tr>               <!-- row 5   -->
         <td>17:00</td>        <!-- time    -->
         <td>Finish</td>        <!-- content -->
@@ -94,6 +98,10 @@
             <ul>Animal Telemetry</ul>
           </em>
         </td>
+      </tr>
+      <tr>
+        <td>16:30</td>      <!-- time   -->
+        <td>Return to Main Room</td>    <!-- content -->
       </tr>
       <tr>               <!-- row 5   -->
         <td>17:00</td>        <!-- time    -->


### PR DESCRIPTION
Following conversation today, added additional timeslots in the schedule:

Day 1 16:30 - gives time for Node Managers to introduce themselves, recap of day 1, looking forward to day 2 etc.
Day 2 16:30 - recap of workshop, continuining the conversation, show of hands who wants to participate in day 3.